### PR TITLE
Fix codec name string comparison in GetStreamTypeInfo

### DIFF
--- a/src/spatialmp4/utils.cc
+++ b/src/spatialmp4/utils.cc
@@ -76,7 +76,7 @@ void PrintStreamInfo(AVFormatContext* pFormatCtx) {
 std::unordered_map<int, StreamType> GetStreamTypeInfo(AVFormatContext* pFormatCtx) {
   std::unordered_map<int, StreamType> stream_type_info;
   for (int i = 0; i < pFormatCtx->nb_streams; i++) {
-    const char* codec_name = avcodec_get_name(pFormatCtx->streams[i]->codecpar->codec_id);
+    std::string codec_name = avcodec_get_name(pFormatCtx->streams[i]->codecpar->codec_id);
 
     if (codec_name == "aac") {
       stream_type_info[i] = MEDIA_TYPE_AUDIO;


### PR DESCRIPTION
- `GetStreamTypeInfo` uses `==` to compare `const char*` returned by `avcodec_get_name()` against string literals, which is pointer comparison, not string comparison
- Works on Linux by accident (GCC merges identical string literals), fails on macOS (Clang doesn't), causing all streams to be classified as `"unknown"`
- Fix: change `const char*` to `std::string`
