### PR TITLE
Fix RGBD loading in point cloud example

### DIFF
--- a/examples/python/generate_pcd.py
+++ b/examples/python/generate_pcd.py
@@ -103,9 +103,7 @@ def generate_pcd(
     )
 
     while reader.has_next():
-        # rgbd = reader.load_rgbd(True)
-        rgb_frame, depth_frame = reader.load_both()
-        import ipdb; ipdb.set_trace()
+        rgbd = reader.load_rgbd(True)
 
         if topk is not None and reader.get_index() >= topk:
             break


### PR DESCRIPTION
## Summary

- restore the intended `Reader.load_rgbd(True)` call in the point-cloud example
- remove the unconditional `ipdb` breakpoint and discarded `load_both()` result
- ensure every later `rgbd` access refers to the frame loaded by the loop

Addresses #18.

## Validation

- `uvx ruff check --no-cache --select F821 --output-format concise examples/python/generate_pcd.py`
- AST parse of all 15 tracked Python files
- structural assertion that `load_rgbd` assigns `rgbd` and no `ipdb` import remains
- `python -m pytest -q -p no:cacheprovider python/tests/test_godot_depth_rgb_align.py python/tests/test_godot_spool_pack.py` (`16 passed, 1 skipped`; the patched-FFmpeg integration test is skipped when that external environment is unavailable)

A full point-cloud run was not performed because it requires a built `spatialmp4` extension plus the example's Open3D runtime and suitable capture input.